### PR TITLE
Use env instead of explicit path in shebang

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 require("./dist/index.js");


### PR DESCRIPTION
Using an explicit path to `node` in the shebang assumes node lives in
that location. This is not always true (macOS). But if `env node` is
used instead, it all works out.